### PR TITLE
Add the --ignore-certificate-errors flag

### DIFF
--- a/src/Dusk.php
+++ b/src/Dusk.php
@@ -136,6 +136,16 @@ class Dusk
     {
         return $this->addArgument('--no-sandbox');
     }
+    
+    /**
+     * Disable the SSL protection.
+     *
+     * @return $this
+     */
+    public function noSsl()
+    {
+        return $this->addArgument('--ignore-certificate-errors');
+    }
 
     /**
      * Set the initial browser window size.

--- a/src/Dusk.php
+++ b/src/Dusk.php
@@ -138,11 +138,11 @@ class Dusk
     }
     
     /**
-     * Disable the SSL protection.
+     * Ignore SSL certificate error messages.
      *
      * @return $this
      */
-    public function noSsl()
+    public function ignoreSslErrors()
     {
         return $this->addArgument('--ignore-certificate-errors');
     }


### PR DESCRIPTION
Hi, thanks for creating this package! It really helped me a lot while working on an in house project for content importing from an old website.

I faced some troubles trying to access the webpage due to an expired SSL certificate issue **By default, the browser does not allow to access non-SSL protected content displaying only a white page** Trying to fix the certificate directly on the server was not an option because we had no access to that server anymore.

I think this method will be useful for those people who may face the same issue. 

Cheers! Keep the good work going ⛷